### PR TITLE
compatibility with Node 5.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: node_js
 node_js:
+  - "5"
+  - "4"
   - "0.12"
   - "iojs"
 branches:

--- a/lib/ocsp/cache.js
+++ b/lib/ocsp/cache.js
@@ -49,14 +49,6 @@ Cache.prototype.request = function request(id, data, callback) {
     callback = null;
   }
 
-  // Check that url isn't blacklisted
-  this.filter(data.url, function(err) {
-    if (err)
-      return done(err, null);
-
-    ocsp.utils.getResponse(data.url, data.ocsp, onResponse);
-  });
-
   function onResponse(err, ocsp) {
     if (err)
       return done(err);
@@ -74,6 +66,15 @@ Cache.prototype.request = function request(id, data, callback) {
       });
     });
   }
+
+  // Check that url isn't blacklisted
+  this.filter(data.url, function(err) {
+    if (err)
+      return done(err, null);
+
+    ocsp.utils.getResponse(data.url, data.ocsp, onResponse);
+  });
+
 };
 
 Cache.prototype.getMaxStoreTime = function getMaxStoreTime(response, callback) {

--- a/lib/ocsp/check.js
+++ b/lib/ocsp/check.js
@@ -7,6 +7,19 @@ var rfc2560 = require('asn1.js-rfc2560');
 module.exports = function check(options, cb) {
   var sync = true;
   var req;
+
+  function done(err, data) {
+    if (sync) {
+      sync = false;
+      process.nextTick(function() {
+        cb(err, data);
+      });
+      return;
+    }
+
+    cb(err, data);
+  }
+
   try {
     req = ocsp.request.generate(options.cert, options.issuer);
   } catch (e) {
@@ -30,16 +43,4 @@ module.exports = function check(options, cb) {
   });
 
   sync = false;
-
-  function done(err, data) {
-    if (sync) {
-      sync = false;
-      process.nextTick(function() {
-        cb(err, data);
-      });
-      return;
-    }
-
-    cb(err, data);
-  }
 };

--- a/lib/ocsp/server.js
+++ b/lib/ocsp/server.js
@@ -64,6 +64,20 @@ Server.prototype.handler = function handler(req, res) {
       chunks.push(chunk);
   });
 
+  function errRes(status) {
+    return rfc2560.OCSPResponse.encode({
+      responseStatus: status
+    }, 'der');
+  }
+
+  function done(out) {
+    res.writeHead(200, {
+      'Content-Type': 'application/ocsp-response',
+      'Content-Length': out.length
+    });
+    res.end(out);
+  }
+
   var self = this;
   req.on('end', function() {
     var body = Buffer.concat(chunks);
@@ -86,19 +100,6 @@ Server.prototype.handler = function handler(req, res) {
     });
   });
 
-  function errRes(status) {
-    return rfc2560.OCSPResponse.encode({
-      responseStatus: status
-    }, 'der');
-  }
-
-  function done(out) {
-    res.writeHead(200, {
-      'Content-Type': 'application/ocsp-response',
-      'Content-Length': out.length
-    });
-    res.end(out);
-  }
 };
 
 Server.prototype.getResponses = function getResponses(req, cb) {

--- a/package.json
+++ b/package.json
@@ -17,13 +17,13 @@
     "jscs": "^2.4.0",
     "jshint": "^2.8.0",
     "mocha": "^2.2.5",
-    "selfsigned.js": "^1.2.0"
+    "selfsigned.js": "^3.0.1"
   },
   "dependencies": {
-    "asn1.js": "^2.0.3",
-    "asn1.js-rfc2560": "^2.1.0",
-    "asn1.js-rfc3280": "^2.1.0",
-    "async": "^1.0.0",
+    "asn1.js": "^4.5.2",
+    "asn1.js-rfc2560": "^4.0.0",
+    "asn1.js-rfc3280": "^4.0.0",
+    "async": "^1.5.2",
     "simple-lru-cache": "0.0.2"
   }
 }


### PR DESCRIPTION
Minor changes and newer dependencies for Node 5.x compatibility.  It seems that old **asn1.js** is what [broke bud-tls tests](https://github.com/indutny/bud/pull/84) on Node 5.x.