### PR TITLE
Add server's cert to ocsp response

### DIFF
--- a/lib/ocsp/server.js
+++ b/lib/ocsp/server.js
@@ -18,10 +18,10 @@ function Server(options) {
   }, options);
 
   this.key = this.options.key;
-  this.cert = rfc5280.Certificate.decode(
+  this.certroot = rfc5280.Certificate.decode(
       ocsp.utils.toDER(options.cert, 'CERTIFICATE'),
       'der');
-  this.cert = this.cert.tbsCertificate;
+  this.cert = this.certroot.tbsCertificate;
 
   var issuerName = rfc5280.Name.encode(this.cert.subject, 'der');
   var issuerKey = this.cert.subjectPublicKeyInfo.subjectPublicKey.data;
@@ -129,9 +129,12 @@ Server.prototype.getResponses = function getResponses(req, cb) {
       signatureAlgorithm: {
         algorithm: ocsp.utils.signRev.sha512WithRSAEncryption
       },
-      signature: null
 
-      // TODO(indutny): send certs?
+      signature: null,
+
+      certs: [
+        self.certroot
+      ]
     };
 
     var sign = crypto.createSign('sha512WithRSAEncryption');


### PR DESCRIPTION
`openssl ocsp` expects a cert in the OCSP response. This fix adds the cert to the response and makes openssl happy.

Tests are failing even without this change, giving the same error as in #16 