### PR TITLE
travis: replace node 5 with node 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,16 @@
 language: node_js
 node_js:
-  - "5"
+  - "6"
   - "4"
   - "0.12"
   - "iojs"
+
+matrix:
+  fast_finish: true
+  allow_failures:
+    - node_js: "0.12"
+    - node_js: "iojs"
+
 branches:
   only:
     - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,7 @@ matrix:
 branches:
   only:
     - master
+
+script:
+  - npm run lint
+  - npm test

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "OCSP Stapling implementation",
   "main": "lib/ocsp.js",
   "scripts": {
-    "test": "mocha test/*-test.js && jshint lib/*.js lib/**/*.js && jscs lib/*.js lib/**/*.js test/*.js test/**/*.js"
+    "lint": "jshint lib/*.js lib/**/*.js && jscs lib/*.js lib/**/*.js test/*.js test/**/*.js",
+    "test": "mocha test/*-test.js"
   },
   "keywords": [
     "OCSP",


### PR DESCRIPTION
- split lint & test into separate scripts (so one can: npm run lint)
- fast finish & ignore test failures on iojs & 0.12