### PR TITLE
agent: return error when cert auth fails

### DIFF
--- a/lib/ocsp/agent.js
+++ b/lib/ocsp/agent.js
@@ -67,6 +67,10 @@ Agent.prototype.createConnection = function createConnection(port,
 Agent.prototype.handleOCSPResponse = function handleOCSPResponse(socket,
                                                                  stapling,
                                                                  cb) {
+  if (!socket.authorized) {
+    return cb(new Error(socket.authorizationError))
+  }
+
   var cert = socket.ssl.getPeerCertificate(true);
   var issuer = cert.issuerCertificate;
 

--- a/test/agent-test.js
+++ b/test/agent-test.js
@@ -32,3 +32,27 @@ describe('OCSP Agent', function() {
     });
   });
 });
+
+describe('OCSP Agent failed', function() {
+  var a;
+  beforeEach(function() {
+    a = new ocsp.Agent();
+  });
+
+  var websites = [
+    "p.vj-vid.com",
+    "vast.bp3861034.btrll.com"
+  ];
+
+  websites.forEach(function(host) {
+    it('should connect and emit error ' + host, function(cb) {
+      var req = https.get({
+        host: host,
+        port: 443,
+        agent: a
+      }).on('error', (e) => {
+        cb();
+      });
+    })
+  });
+})


### PR DESCRIPTION
Sites without intermediate certs in chain
and other ssl error ends up with sockets.ssl
being null and that causes Type error in agent.