### PR TITLE
Try/catch the http request

### DIFF
--- a/lib/ocsp/agent.js
+++ b/lib/ocsp/agent.js
@@ -153,8 +153,12 @@ Agent.prototype.fetchIssuer = function fetchIssuer(cert, stapling, cb) {
       });
     }
 
-    http.get(uri)
-        .on('error', done)
-        .on('response', onResponse);
+    try {
+     http.get(uri)
+         .on('error', done)
+          .on('response', onResponse);
+    } catch (e) {
+      return done(e)
+    }
   });
 };


### PR DESCRIPTION
When checking self-signed certificates, there's a chance the OCSP is on a file:// path. At the moment, this throws an uncatchable error.
This catches that and passes that on.