### PR TITLE
agent: fix `tlsSocket.getPeerCertificate()` null reference

### DIFF
--- a/lib/ocsp/agent.js
+++ b/lib/ocsp/agent.js
@@ -67,10 +67,10 @@ Agent.prototype.createConnection = function createConnection(port,
 Agent.prototype.handleOCSPResponse = function handleOCSPResponse(socket,
                                                                  stapling,
                                                                  cb) {
-  var cert = socket.ssl.getPeerCertificate(true);
-  var issuer = cert.issuerCertificate;
+  var cert = (socket.ssl || socket).getPeerCertificate(true);
+  var issuer = cert && cert.issuerCertificate;
 
-  cert = cert.raw;
+  cert = cert && cert.raw;
   try {
     cert = rfc5280.Certificate.decode(cert, 'der');
 


### PR DESCRIPTION
Patch for #32.